### PR TITLE
Do not pass domain as argument to maintenance mode script

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It is important to check whether the template used as the basis for the ingress 
 To enable or disable the maintance page in a given namespace:
 
 ```
-./bin/maintenance_mode <action> <mamespace> <hostname_postfix>
+./bin/maintenance_mode <action> <namespace>
 ```
 
 `action` is one of:
@@ -41,10 +41,3 @@ To enable or disable the maintance page in a given namespace:
 - formbuilder-services-test-production
 - formbuilder-services-live-dev
 - formbuilder-services-live-production
-
-`hostname_postfix` is one of:
-
-- `dev.test.form.service.justice.gov.uk` if the namespace is `formbuilder-services-test-dev`
-- `test.form.service.justice.gov.uk` if the namespace is `formbuilder-services-test-production`
-- `form.service.justice.gov.uk` if the namespace is `formbuilder-services-live-dev`
-- `form.service.justice.gov.uk` if the namespace is `formbuilder-services-live-production`

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This can either be done by redeploying the ingress or doing an in-place edit of 
 
 ## Custom HTML
 
-The HTML provided by default is a basic MoJ Forms braned page. Customise it how you see fit. Raise a PR. Merge it. Cross fingers.
+The HTML provided by default is a basic MoJ Forms branded page. Customise it how you see fit. Raise a PR. Merge it. Cross fingers.
 
 ## Enabling and Disabling namespace level maintenance page
 

--- a/bin/maintenance_mode
+++ b/bin/maintenance_mode
@@ -3,7 +3,6 @@ set -e -o pipefail
 
 action=$1
 namespace=$2
-hostname_postfix=$3
 
 if [[ ${namespace} != *formbuilder-services* ]]; then
   echo '*************************************************'
@@ -32,9 +31,17 @@ if [[ ! ${action} =~ (enable|disable) ]]; then
   exit 1
 fi
 
-if [[ -z "${hostname_postfix}" ]]; then
+if [[ ${namespace} == 'formbuilder-services-test-dev' ]]; then
+  hostname_postfix='dev.test.form.service.justice.gov.uk'
+elif [[ ${namespace} == 'formbuilder-services-test-production' ]]; then
+  hostname_postfix='test.form.service.justice.gov.uk'
+elif [[ ${namespace} == 'formbuilder-services-live-dev' ]]; then
+  hostname_postfix='dev.form.service.justice.gov.uk'
+elif [[ ${namespace} == 'formbuilder-services-live-production' ]]; then
+  hostname_postfix='form.service.justice.gov.uk'
+else
   echo '*************************************************'
-  echo 'Hostname Postfix must be provided. Check the README'
+  echo 'Invalid namespace provided. Check the README'
   echo '*************************************************'
   echo
   exit 1

--- a/bin/maintenance_mode
+++ b/bin/maintenance_mode
@@ -32,7 +32,7 @@ if [[ ! ${action} =~ (enable|disable) ]]; then
   exit 1
 fi
 
-if [[ -z "${hostname_prostfix}" ]]; then
+if [[ -z "${hostname_postfix}" ]]; then
   echo '*************************************************'
   echo 'Hostname Postfix must be provided. Check the README'
   echo '*************************************************'
@@ -74,7 +74,7 @@ for line in ${ingresses}; do
       else
         service_name="${service_slug}"
       fi
-      echo "Serice name is ${service_name}"
+      echo "Service name is ${service_name}"
       echo
 
       if [[ ${action} == 'enable' ]]; then
@@ -91,7 +91,7 @@ for line in ${ingresses}; do
       fi
 
       filepath="${namespace_directory}/${ingress}.yaml"
-      echo "Coyping template to ${filepath}"
+      echo "Copying template to ${filepath}"
       cp "./templates/ingress.yaml" "${filepath}"
       echo
 


### PR DESCRIPTION
It is safer if we do not rely on the person running the script to pass
the correct domain as an argument when running the maintenance mode
script.

Hard code the domain for each namespace instead.