### PR TITLE
Redirect all traffic to route

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
  FROM bitnami/nginx:latest
 
 COPY . /opt/bitnami/nginx/html
+COPY conf/maintenance_page.conf /opt/bitnami/nginx/conf/server_blocks/

--- a/conf/maintenance_page.conf
+++ b/conf/maintenance_page.conf
@@ -1,0 +1,17 @@
+server {
+    # Port to listen on, can also be set in IP:PORT format
+    listen  8080;
+
+    include  "/opt/bitnami/nginx/conf/bitnami/*.conf";
+
+    location /status {
+        stub_status on;
+        access_log   off;
+        allow 127.0.0.1;
+        deny all;
+    }
+
+    location / {
+        try_files $uri $uri/ /;
+    }
+}


### PR DESCRIPTION
We want all traffic to be redirected to the root page to show the maintenance page. Set the nginx config to do just that.